### PR TITLE
Fix import path for test assembler script

### DIFF
--- a/assemblers/test_assembler.py
+++ b/assemblers/test_assembler.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 from typing import Dict, Any, List
 from dataclasses import dataclass
+import os
+import sys
+
+# Allow running this script directly (e.g. `python assemblers/test_assembler.py`)
+# by ensuring the project root is on the module search path.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from utils.builder_core import BuilderCore
 


### PR DESCRIPTION
## Summary
- allow `assemblies/test_assembler.py` to run directly by adding the project root to `sys.path`

## Testing
- `python assemblers/test_assembler.py`

------
https://chatgpt.com/codex/tasks/task_e_68a90b15cc7c8333aba5f0238bbd53a0