### PR TITLE
Add evidence-based reasoning for enhanced QA

### DIFF
--- a/generators/enhanced_llm_generator.py
+++ b/generators/enhanced_llm_generator.py
@@ -326,6 +326,12 @@ NOC 운영자 관점에서, 서비스 가용성과 관련된 복합적 상황 �
                                         "step": {"type": "integer"},
                                         "description": {"type": "string"},
                                         "required_metric": {"type": "string"},
+                                        "metric_params": {
+                                            "type": "object",
+                                            "description": "calculate_metric 호출 시 전달할 파라미터",
+                                            "properties": {},
+                                            "additionalProperties": True
+                                        },
                                         "synthesis": {
                                             "type": "string",
                                             "enum": ["fetch", "compare", "summarize"]
@@ -372,7 +378,7 @@ NOC 운영자 관점에서, 서비스 가용성과 관련된 복합적 상황 �
 2. 실무 경험과 전문 지식 요구
 3. 단순한 팩트 조회를 넘어선 추론
 4. {template.answer_type} 형태의 상세한 답변 필요성
-5. **reasoning_plan**: 정답 도출을 위한 단계별 절차
+5. **reasoning_plan**: 각 단계에 required_metric과 metric_params(필요 시)를 명시
 
 **엄격한 규칙: 모든 응답은 반드시 한국어로만 작성해주십시오.**
 """

--- a/integrated_pipeline.py
+++ b/integrated_pipeline.py
@@ -282,6 +282,7 @@ class NetworkConfigDatasetGenerator:
                     "reasoning_plan": reasoning_plan,
                     "reasoning_requirement": eq.get("reasoning_requirement", ""),
                     "expected_analysis_depth": eq.get("expected_analysis_depth", "detailed"),
+                    "evidence": answer_agent.evidence,
                 },
             )
             sample.context = self._create_enhanced_context(network_facts, sample)

--- a/utils/builder_core.py
+++ b/utils/builder_core.py
@@ -159,10 +159,18 @@ class BuilderCore:
         pre["ssh_missing"] = set([ (d.get("system",{}).get("hostname") or d.get("file")) for d in self.devices if not self._ssh_on(d)])
         return pre
 
-    def calculate_metric(self, metric: str) -> Any:
-        """주어진 메트릭을 계산하여 값을 반환합니다."""
+    def calculate_metric(self, metric: str, params: Dict[str, Any] | None = None) -> Any:
+        """주어진 메트릭을 계산하여 값을 반환합니다.
+
+        Parameters
+        ----------
+        metric: str
+            계산할 메트릭 이름
+        params: Dict[str, Any] | None
+            메트릭 계산에 필요한 추가 파라미터. 예) {"asn": "65000"}
+        """
         pre = self._precompute()
-        _atype, value = self._answer_for_metric(metric, {}, pre)
+        _atype, value = self._answer_for_metric(metric, params or {}, pre)
         return value
 
     # GIA-Re/utils/builder_core.py 에 새로운 함수 추가


### PR DESCRIPTION
## Summary
- allow `BuilderCore.calculate_metric` to accept parameters
- execute reasoning steps with parameters and synthesize natural language answers via LLM
- update enhanced question generator and pipeline to pass reasoning evidence

## Testing
- `PYTHONPATH=. pytest assemblers/test_assembler.py test_evaluation_system.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a95d4dc070833398b1f9a3398cb440