### PR TITLE
Standardize ground truth responses

### DIFF
--- a/demo_output/basic_dataset.json
+++ b/demo_output/basic_dataset.json
@@ -28,7 +28,8 @@
         "metric": "ssh_missing_count"
       },
       "topic": "Security_Policy"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-IBGP_FULLMESH_OK-11305",
@@ -58,7 +59,8 @@
         "metric": "ibgp_fullmesh_ok"
       },
       "topic": "BGP_Consistency"
-    }
+    },
+    "ground_truth": "예"
   },
   {
     "id": "BASIC_DSL-IBGP_FULLMESH_OK-32097",
@@ -85,7 +87,8 @@
         "metric": "ibgp_fullmesh_ok"
       },
       "topic": "BGP_Consistency"
-    }
+    },
+    "ground_truth": "예"
   },
   {
     "id": "BASIC_DSL-IBGP_FULLMESH_OK-56904",
@@ -112,7 +115,8 @@
         "metric": "ibgp_fullmesh_ok"
       },
       "topic": "BGP_Consistency"
-    }
+    },
+    "ground_truth": "예"
   },
   {
     "id": "BASIC_DSL-IBGP_MISSING_PAIRS_COUNT-11305",
@@ -142,7 +146,8 @@
         "metric": "ibgp_missing_pairs_count"
       },
       "topic": "BGP_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-IBGP_MISSING_PAIRS_COUNT-32097",
@@ -169,7 +174,8 @@
         "metric": "ibgp_missing_pairs_count"
       },
       "topic": "BGP_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-IBGP_MISSING_PAIRS_COUNT-56904",
@@ -196,7 +202,8 @@
         "metric": "ibgp_missing_pairs_count"
       },
       "topic": "BGP_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-VRF_WITHOUT_RT_COUNT-10097",
@@ -227,7 +234,8 @@
         "metric": "vrf_without_rt_count"
       },
       "topic": "VRF_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-VRF_INTERFACE_BIND_COUNT-16749",
@@ -255,7 +263,8 @@
         "metric": "vrf_interface_bind_count"
       },
       "topic": "VRF_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-VRF_INTERFACE_BIND_COUNT-59999",
@@ -283,7 +292,8 @@
         "metric": "vrf_interface_bind_count"
       },
       "topic": "VRF_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-VRF_INTERFACE_BIND_COUNT-47142",
@@ -311,7 +321,8 @@
         "metric": "vrf_interface_bind_count"
       },
       "topic": "VRF_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-VRF_INTERFACE_BIND_COUNT-61741",
@@ -339,7 +350,8 @@
         "metric": "vrf_interface_bind_count"
       },
       "topic": "VRF_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-VRF_INTERFACE_BIND_COUNT-19650",
@@ -367,7 +379,8 @@
         "metric": "vrf_interface_bind_count"
       },
       "topic": "VRF_Consistency"
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "BASIC_DSL-VRF_INTERFACE_BIND_COUNT-61631",
@@ -395,6 +408,7 @@
         "metric": "vrf_interface_bind_count"
       },
       "topic": "VRF_Consistency"
-    }
+    },
+    "ground_truth": "0"
   }
 ]

--- a/demo_output/enhanced_dataset.json
+++ b/demo_output/enhanced_dataset.json
@@ -54,7 +54,8 @@
         "step_2_ibgp_missing_pairs_count": 0,
         "step_3_bgp_inconsistent_as_count": null
       }
-    }
+    },
+    "ground_truth": "영향 없음"
   },
   {
     "id": "ENHANCED_ENHANCED-ANALYTICAL-002",
@@ -111,7 +112,8 @@
         "step_2_interface_count": 5,
         "step_3_ospf_area_count": null
       }
-    }
+    },
+    "ground_truth": "5"
   },
   {
     "id": "ENHANCED_ENHANCED-DIAGNOSTIC-001",
@@ -166,7 +168,8 @@
         "step_2_bgp_inconsistent_as_count": null,
         "step_3_bgp_missing_pairs": null
       }
-    }
+    },
+    "ground_truth": "정상"
   },
   {
     "id": "ENHANCED_ENHANCED-DIAGNOSTIC-002",
@@ -219,7 +222,8 @@
         "step_2_aaa_enabled_devices": null,
         "step_3_ssh_all_enabled_bool": true
       }
-    }
+    },
+    "ground_truth": "낮음"
   },
   {
     "id": "ENHANCED_ENHANCED-SYNTHETIC-001",
@@ -286,7 +290,8 @@
         "step_3_bgp_inconsistent_as_count": null,
         "step_4_l2vpn_issues": null
       }
-    }
+    },
+    "ground_truth": "L2VPN 및 L3VPN 장비 점검"
   },
   {
     "id": "ENHANCED_ENHANCED-SYNTHETIC-002",
@@ -349,7 +354,8 @@
         "step_3_bgp_missing_pairs": null,
         "step_4_bgp_peer_count": null
       }
-    }
+    },
+    "ground_truth": "추가 조치 없음"
   },
   {
     "id": "ENHANCED_ENHANCED-ANALYTICAL-001",
@@ -411,7 +417,8 @@
         "step_2_bgp_peer_count": null,
         "step_3_ospf_area_count": null
       }
-    }
+    },
+    "ground_truth": "필요 없음"
   },
   {
     "id": "ENHANCED_ENHANCED-ANALYTICAL-002",
@@ -471,7 +478,8 @@
         "step_2_vrf_without_rt_count": 0,
         "step_3_aaa_enabled_devices": null
       }
-    }
+    },
+    "ground_truth": "불필요"
   },
   {
     "id": "ENHANCED_ENHANCED-DIAGNOSTIC-001",
@@ -524,7 +532,8 @@
         "step_2_aaa_enabled_devices": null,
         "step_3_aaa_enabled_devices": null
       }
-    }
+    },
+    "ground_truth": "아니오"
   },
   {
     "id": "ENHANCED_ENHANCED-DIAGNOSTIC-002",
@@ -584,7 +593,8 @@
         "step_2_ssh_missing_count": 0,
         "step_3_ssh_all_enabled_bool": true
       }
-    }
+    },
+    "ground_truth": "예"
   },
   {
     "id": "ENHANCED_ENHANCED-ANALYTICAL-001",
@@ -641,7 +651,8 @@
         "step_2_bgp_peer_count": null,
         "step_3_bgp_peer_count": null
       }
-    }
+    },
+    "ground_truth": "0"
   },
   {
     "id": "ENHANCED_ENHANCED-ANALYTICAL-002",
@@ -686,6 +697,7 @@
         "step_1_l2vpn_unidir_count": 0,
         "step_2_l2vpn_issues": null
       }
-    }
+    },
+    "ground_truth": "없음"
   }
 ]


### PR DESCRIPTION
## Summary
- Refine enhanced dataset answers with explicit tokens like "영향 없음", "정상", and "불필요" for deterministic evaluation
- Add `_standardize_ground_truth` in `integrated_pipeline.py` to normalize counts, status flags, lists, and command outputs during validation

## Testing
- `pip install --break-system-packages -r requirements.txt`
- `pip install --break-system-packages pytest`
- `pip install --break-system-packages numpy`
- `pip install --break-system-packages openai`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac7259c084833397336693593db879